### PR TITLE
fix commands containing '|' breaking suggestion parser

### DIFF
--- a/src/ai/helpme.zsh
+++ b/src/ai/helpme.zsh
@@ -85,8 +85,8 @@ _sage_helpme_fix() {
         return 1
     fi
 
-    local last_cmd="${last_row%%|*}"
-    local last_exit="${last_row##*|}"
+    local last_cmd="${last_row%%${_SAGE_SEP}*}"
+    local last_exit="${last_row##*${_SAGE_SEP}}"
 
     if [[ "$last_exit" == "0" ]]; then
         echo "  Last command succeeded — nothing to fix."

--- a/src/core/cli.zsh
+++ b/src/core/cli.zsh
@@ -295,7 +295,7 @@ FROM (SELECT * FROM weight_accepts ORDER BY timestamp DESC LIMIT 500);")
 
     if [[ -n "$shares" ]]; then
         local -a share_fields
-        share_fields=("${(@s:|:)shares}")
+        share_fields=("${(@ps:$_SAGE_SEP:)shares}")
         printf "  ${m}frequency${r}    %s\n" "${share_fields[1]:-0}"
         printf "  ${m}recency${r}      %s\n" "${share_fields[2]:-0}"
         printf "  ${m}directory${r}    %s\n" "${share_fields[3]:-0}"

--- a/src/core/db.zsh
+++ b/src/core/db.zsh
@@ -28,7 +28,10 @@ _sage_coproc_start() {
     # stay valid and `.quit` from _sage_coproc_stop still gives it a
     # clean shutdown.
     setopt local_options no_monitor no_notify
-    coproc sqlite3 -separator "$_SAGE_SEP" -cmd ".mode list" "$ZSH_SAGE_DB" 2>/dev/null
+    # NOTE: ".separator" must come as a -cmd AFTER ".mode list" — the
+    # -separator flag is applied first and ".mode list" resets the
+    # separator back to the default '|'.
+    coproc sqlite3 -cmd ".mode list" -cmd ".separator ${_SAGE_SEP}" "$ZSH_SAGE_DB" 2>/dev/null
     disown 2>/dev/null
 
     # Verify the coproc actually started

--- a/src/core/db.zsh
+++ b/src/core/db.zsh
@@ -7,6 +7,9 @@
 
 typeset -g _SAGE_COPROC_ALIVE=0
 typeset -g _SAGE_EOF_SENTINEL="__SAGE_e0f_7d2b9k__"
+# ASCII Unit Separator — used as field delimiter for sqlite output so
+# commands containing '|' (e.g. `ps -ef | grep foo`) don't corrupt parsing.
+typeset -g _SAGE_SEP=$'\x1f'
 
 # ── Coprocess management ─────────────────────────────────────────
 
@@ -25,7 +28,7 @@ _sage_coproc_start() {
     # stay valid and `.quit` from _sage_coproc_stop still gives it a
     # clean shutdown.
     setopt local_options no_monitor no_notify
-    coproc sqlite3 -separator '|' -cmd ".mode list" "$ZSH_SAGE_DB" 2>/dev/null
+    coproc sqlite3 -separator "$_SAGE_SEP" -cmd ".mode list" "$ZSH_SAGE_DB" 2>/dev/null
     disown 2>/dev/null
 
     # Verify the coproc actually started
@@ -147,7 +150,7 @@ _sage_db_exec() {
 
 # Fallback: run via sqlite3 fork (for init and import where coproc isn't ready)
 _sage_db_fork() {
-    printf '%s' "$1" | sqlite3 -separator '|' "$ZSH_SAGE_DB"
+    printf '%s' "$1" | sqlite3 -separator "$_SAGE_SEP" "$ZSH_SAGE_DB"
 }
 
 # ── Database initialization ──────────────────────────────────────

--- a/src/core/scorer.zsh
+++ b/src/core/scorer.zsh
@@ -227,7 +227,7 @@ LIMIT 1;"
 
     local result
     result=$(_sage_db_query "$sql")
-    [[ -n "$result" ]] && printf '%s' "${result%%|*}"
+    [[ -n "$result" ]] && printf '%s' "${result%%${_SAGE_SEP}*}"
 }
 
 # Same as _sage_rank_candidates but returns "score|command" for confidence coloring
@@ -240,7 +240,7 @@ _sage_rank_with_score() {
     local seq_override
     seq_override=$(_sage_sequence_override "$prefix" "$prev_cmd")
     if [[ -n "$seq_override" ]]; then
-        printf '0.95|%s' "$seq_override"
+        printf '0.95%s%s' "$_SAGE_SEP" "$seq_override"
         return
     fi
 
@@ -364,7 +364,7 @@ _sage_rank_top_n() {
     local seq_cmd=""
     seq_cmd=$(_sage_sequence_override "$prefix" "$prev_cmd")
     if [[ -n "$seq_cmd" ]]; then
-        seq_override="0.95|${seq_cmd}"
+        seq_override="0.95${_SAGE_SEP}${seq_cmd}"
         # Reduce limit by 1 since override takes a slot
         limit=$((limit - 1))
     fi
@@ -456,7 +456,7 @@ LIMIT ${limit};"
         # Output rest, skipping the override command if it appears in scored results
         if [[ -n "$results" ]]; then
             echo "$results" | while IFS= read -r line; do
-                [[ "$line" == *"|${seq_cmd}" ]] && continue
+                [[ "$line" == *"${_SAGE_SEP}${seq_cmd}" ]] && continue
                 echo "$line"
             done
         fi
@@ -472,7 +472,7 @@ _sage_score_candidate() {
     local prev_cmd="$3"
     local now="$4"
 
-    # Parse pipe-delimited fields
+    # Parse pipe-delimited fields (test helper — fixtures use literal '|')
     local cmd="${candidate%%|*}";        candidate="${candidate#*|}"
     local freq="${candidate%%|*}";       candidate="${candidate#*|}"
     local last_used="${candidate%%|*}";  candidate="${candidate#*|}"

--- a/src/core/widget.zsh
+++ b/src/core/widget.zsh
@@ -130,7 +130,7 @@ _sage_update_suggestion() {
         # score|command|freq_contrib|rec_contrib|dir_contrib|seq_contrib|succ_contrib
         # (sequence override fast path returns only "score|command" — contribs will be empty)
         local -a fields
-        fields=("${(@s:|:)result}")
+        fields=("${(@ps:$_SAGE_SEP:)result}")
         local score="${fields[1]}"
         local suggestion="${fields[2]}"
 
@@ -298,8 +298,8 @@ _sage_cycle_widget() {
 
     # Display the current cycle entry
     local entry="${_SAGE_CYCLE_RESULTS[$_SAGE_CYCLE_INDEX]}"
-    local score="${entry%%|*}"
-    local suggestion="${entry#*|}"
+    local score="${entry%%${_SAGE_SEP}*}"
+    local suggestion="${entry#*${_SAGE_SEP}}"
 
     if [[ -n "$suggestion" && "$suggestion" == "$prefix"* ]]; then
         _sage_highlight_reset

--- a/tests/test_scenarios.sh
+++ b/tests/test_scenarios.sh
@@ -401,6 +401,14 @@ assert_not_empty "Single-quoted command retrievable" "$r_quote"
 
 r_pipe=$(_sage_rank_candidates "cat file" "/tmp" "")
 assert_not_empty "Piped command retrievable" "$r_pipe"
+# Regression (#8): '|' in the command must not be eaten by field parsing
+assert_eq "Piped command returned intact" "cat file.txt | grep error | wc -l" "$r_pipe"
+
+r_pipe_scored=$(_sage_rank_with_score "cat file" "/tmp" "")
+local -a pipe_fields
+pipe_fields=("${(@ps:$_SAGE_SEP:)r_pipe_scored}")
+assert_eq "Score row: command field intact despite pipes" "cat file.txt | grep error | wc -l" "${pipe_fields[2]}"
+assert_eq "Score row: score field is numeric" "" "${pipe_fields[1]//[0-9.]/}"
 
 r_dollar=$(_sage_rank_candidates "echo \$" "/tmp" "")
 assert_not_empty "Dollar-sign command retrievable" "$r_dollar"
@@ -456,7 +464,7 @@ done
 # Simulate what the widget does: query, cache contribs, record accept
 r=$(_sage_rank_with_score "git" "/repo" "")
 local -a fields
-fields=("${(@s:|:)r}")
+fields=("${(@ps:$_SAGE_SEP:)r}")
 
 # Record as if user pressed right arrow
 _sage_db_record_accept "${fields[3]:-0}" "${fields[4]:-0}" "${fields[5]:-0}" "${fields[6]:-0}" "${fields[7]:-0}"


### PR DESCRIPTION
sqlite3 was started with -separator '|', so output rows like score|command|freq|... could be misparsed when the command itself contained a pipe (e.g. 'ps -ef | grep "my_process"'`).

Switch the field separator to ASCII Unit Separator (0x1f), which can't appear in shell commands. Stored as _SAGE_SEP in db.zsh; producers and parsers in scorer.zsh, widget.zsh, and cli.zsh use it consistently.

Fixes #8 