### PR TITLE
fix test failures from non-C locale and db lock contention

### DIFF
--- a/src/core/db.zsh
+++ b/src/core/db.zsh
@@ -43,6 +43,10 @@ _sage_coproc_start() {
 
     # Enable WAL mode for better concurrent access (multiple tabs)
     _sage_db_query_raw "PRAGMA journal_mode=WAL;" > /dev/null 2>&1
+    # Wait up to 5s when another connection holds the write lock
+    # instead of failing immediately with "database is locked". Matters
+    # for tests and for concurrent activity across multiple terminals.
+    _sage_db_query_raw "PRAGMA busy_timeout=5000;" > /dev/null 2>&1
 }
 
 # Check if coproc is still alive
@@ -137,7 +141,7 @@ _sage_db_exec() {
 
 # Fallback: run via sqlite3 fork (for init and import where coproc isn't ready)
 _sage_db_fork() {
-    printf '%s' "$1" | sqlite3 -separator '|' "$ZSH_SAGE_DB"
+    printf '%s' "$1" | sqlite3 -separator '|' -cmd ".timeout 5000" "$ZSH_SAGE_DB"
 }
 
 # ── Database initialization ──────────────────────────────────────

--- a/src/core/scorer.zsh
+++ b/src/core/scorer.zsh
@@ -467,6 +467,11 @@ LIMIT ${limit};"
 
 # Score a single candidate (kept for testing — uses the same SQL approach)
 _sage_score_candidate() {
+    # Force C numeric locale so bc/printf use '.' as the decimal mark.
+    # Without this, locales like sv_SE produce '0,98' which bc rejects
+    # with "(standard_in) 1: syntax error".
+    local -x LC_NUMERIC=C
+
     local candidate="$1"
     local current_dir="$2"
     local prev_cmd="$3"

--- a/tests/test_db.sh
+++ b/tests/test_db.sh
@@ -12,6 +12,11 @@ FAIL=0
 # Source only what we need
 export ZSH_SAGE_DB="$TEST_DB"
 export ZSH_SAGE_MAX_CANDIDATES=10
+# Force fork-mode for every DB call so each operation opens, commits,
+# and closes within a single sqlite3 process. The persistent coproc
+# would run alongside the verifying `sqlite3 "$TEST_DB" "..."` forks,
+# producing transient `database is locked` failures even under WAL.
+export ZSH_SAGE_NO_COPROC=1
 source "$(dirname $0)/../src/core/db.zsh"
 
 cleanup() {


### PR DESCRIPTION
Two unrelated test reliability issues and one "best practice" fix in live code:

1. Locale: _sage_score_candidate used bc + printf '%f' to compute the score. In locales like sv_SE.UTF-8, printf emits '0,986364' (comma decimal), which bc then rejects with '(standard_in) 1: syntax error'. Set 'local -x LC_NUMERIC=C' so the function always uses '.'.

2. DB lock in tests: test_db.sh writes via the persistent coproc and verifies via a parallel `sqlite3` fork. WAL prevents contention in the common case, but the writer still takes a brief EXCLUSIVE lock at commit; if the verifying fork opens in that microsecond the default busy_timeout=0 returns 'database is locked' immediately. Set ZSH_SAGE_NO_COPROC=1 in the test so every DB call goes through _sage_db_fork — one process at a time, no inter-process contention.

3. DB lock in live code: same risk for users running many terminals that write concurrently (probably not common...). Set busy_timeout=5000 on the coproc (and on _sage_db_fork) so a brief lock causes a retry instead of an immediate failure.